### PR TITLE
ci: update docker build to include arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,26 +7,32 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-32-cores
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: "arm64,arm"
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           file: docker/Dockerfile
           tags: >

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @polkadot/apps
+# madara-app
 
 A Portal into the Polkadot and Substrate networks. Provides a view and interaction layer from a browser.
 
@@ -18,7 +18,7 @@ The repo is split into a number of packages, each representing an application.
 
 Contributions are welcome!
 
-To start off, this repo (along with others in the [@polkadot](https://github.com/polkadot-js/) family) uses yarn workspaces to organize the code. As such, after cloning dependencies _should_ be installed via `yarn`, not via npm, the latter will result in broken dependencies.
+To start off, this repo uses yarn workspaces to organize the code. As such, after cloning dependencies _should_ be installed via `yarn`, not via npm, the latter will result in broken dependencies.
 
 To get started -
 
@@ -35,13 +35,13 @@ To get started -
 You can run a docker container via -
 
 ```
-docker run --rm -it --name polkadot-ui -e WS_URL=ws://someip:9944 -p 80:80 jacogr/polkadot-js-apps:latest
+docker run --rm -it --name madara-ui -e WS_URL=ws://someip:9944 -p 80:80 keep-starknet-strange/madara-app:latest
 ```
 
 To build a docker container containing local changes -
 
 ```
-docker build -t jacogr/polkadot-js-apps -f docker/Dockerfile .
+docker build -t keep-starknet-strange/madara-app -f docker/Dockerfile .
 ```
 
 When using these Docker commands, you can access the UI via http://localhost:80 (or just http://localhost)


### PR DESCRIPTION
Per title, add workflow to build for `arm64`, taking reference from madara's workflow.

`linux/arm64` might work for Mac M1, but needs further testing.

Closes #1 